### PR TITLE
gitignore updated to remove DS_Store and xcuserdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ starapp/Helpers/Constants.swift
 starapp/Helpers/Constants.swift
 starapp/Helpers/Constants.swift
 starapp/Helpers/Constants.swift
+
+.DS_Store
+xcuserdata


### PR DESCRIPTION
The repo contains DS_Store and xcuserdata, which shouldn't be committed. This PR updates to .gitignore.